### PR TITLE
googleapis-common-protos 1.56.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set sha256 = "a88ee8903aa0a81f6c3cec2d5cf62d3c8aa67c06439b0496b49048fb1854ebf4" %}
-{% set version = "1.53.0" %}
+{% set sha256 = "4007500795bcfc269d279f0f7d253ae18d6dc1ff5d5a73613ffe452038b1ec5f" %}
+{% set version = "1.56.0" %}
 {% set name = "googleapis-common-protos" %}
 
 package:


### PR DESCRIPTION
Update googleapis-common-protos to 1.56.0