### PR TITLE
Rebuild ppc64le

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and vc<14]
+  # trigger 1
+   1skip: true  # [win and vc<14]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   # trigger 1
-   1skip: true  # [win and vc<14]
+  skip: true  # [win and vc<14]
 
 requirements:
   build:


### PR DESCRIPTION
`googleapis-common-protos-feedstock 1.53.0` rebuild for python 3.10 support on ppc64le