### PR TITLE
bump to 1.56.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set sha256 = "a88ee8903aa0a81f6c3cec2d5cf62d3c8aa67c06439b0496b49048fb1854ebf4" %}
-{% set version = "1.53.0" %}
+{% set sha256 = "c25873c47279387cfdcbdafa36149887901d36202cb645a0e4f29686bf6e4417" %}
+{% set version = "1.56.4" %}
 {% set name = "googleapis-common-protos" %}
 
 package:
@@ -12,34 +12,24 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and vc<14]
-
-requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    #- cross-python_{{ target_platform }}     # [build_platform != target_platform]
-  host:
-    - python
-    - pip >=18.1
-    - setuptools >=34.0.0
+  skip: true  # [py<37]
 
 outputs:
   - name: {{ name }}
     build:
-      script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --verbose
-      skip: true  # [win and vc<14]
+      script: python -m pip install . --no-deps --ignore-installed --verbose
     requirements:
-      build:
-        - python                                 # [build_platform != target_platform]
-        #- cross-python_{{ target_platform }}     # [build_platform != target_platform]
       host:
         - python
-        - pip >=18.1
-        - protobuf >=3.12.0
-        - setuptools >=34.0.0
+        - pip
+        - setuptools
+        - wheel
       run:
         - python
-        - protobuf >=3.12.0
+        - protobuf >=3.15.0,<5.0.0
+        - libprotobuf
+      run_constrained:
+        - grpcio >=1.0.0,<2.0.0
     test:
       imports:
         - google.api
@@ -93,15 +83,13 @@ outputs:
         - google.type.timeofday_pb2
 
   - name: {{ name }}-grpc
-    build:
-      skip: true  # [win and vc<14]
     requirements:
       host:
         - python
-        - grpcio >=1.0.0
       run:
+        - python
         - {{ pin_subpackage(name, min_pin='x.x', max_pin='x.x') }}
-        - grpcio
+        - grpcio >=1.0.0,<2.0.0
     test:
       imports:
         - google.api
@@ -160,20 +148,12 @@ outputs:
       license: Apache-2.0
       license_file: LICENSE
       license_family: APACHE
-      summary: Common protobufs used in Google APIs
+      summary: Extra grpc requirements for {{ name }}
       description: |
-        {{ name }}-grpc installs {{ name }} and the grpc extra requirements.
-        This repository contains the original interface definitions of public
-        Google APIs that support both REST and gRPC protocols. Reading the original
-        interface definitions can provide a better understanding of Google APIs and
-        help you to utilize them more efficiently. You can also use these definitions
-        with open source tools to generate client libraries, documentation,
-        and other artifacts.
-        **Deprecated Python Versions**
-        Python == 2.7
-        - Python 2.7 support will be removed on January 1, 2020.
-        - protobuf does not support Visual C++ 2008, windows py27 package not available
+        This package installs {{ name }} as well as the additional
+        dependency required to enable grpc support.
       doc_url: https://github.com/googleapis/api-common-protos/blob/master/README.md
+      doc_source_url: https://github.com/googleapis/api-common-protos/blob/master/README.md
       dev_url: https://github.com/googleapis/api-common-protos
 
 about:
@@ -183,18 +163,15 @@ about:
   license_family: APACHE
   summary: Common protobufs used in Google APIs
   description: |
-    This package does not include the grpc extra requirements.
     This repository contains the original interface definitions of public
     Google APIs that support both REST and gRPC protocols. Reading the original
     interface definitions can provide a better understanding of Google APIs and
     help you to utilize them more efficiently. You can also use these definitions
     with open source tools to generate client libraries, documentation,
-    and other artifacts.
-    **Deprecated Python Versions**
-    Python == 2.7
-    - Python 2.7 support will be removed on January 1, 2020.
-    - protobuf does not support Visual C++ 2008, windows py27 package not available
+    and other artifacts. NOTE: to enable gRPC support, the grcpio package must
+    also be installed. The {{ name }}-grpc metapackage accomplishes this.
   doc_url: https://github.com/googleapis/googleapis/blob/master/README.md
+  doc_source_url: https://github.com/googleapis/googleapis/blob/master/README.md
   dev_url: https://github.com/googleapis/googleapis
 
 extra:


### PR DESCRIPTION
- Updated sha256, version
- Relaxed build constraints
- Updated protobuf constraint
- Added explicit libprotobuf constraint to ensure cbc.yaml pin
- Added optional grcpio constraint

I considered removing the `{{ name }}-grpc` metapackage in favor of just using a `run_constrained` entry. However for now it makes sense to keep it. That way, if someone that has already used this metapackage does a `conda update`, it will do the right thing. That said, for new users, it is strictly speaking easier to just install `googleapis-common-protos` and `grcpio`,  and let the `run_constrained` entry ensure compatibility.