### PR TITLE
rebuild without  libprotobuf 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+upload_without_merge: true
+aggregate_check: false
+upload_channels:
+  - marekw
+channels:
+  - marekw
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
 
 outputs:
@@ -27,7 +27,6 @@ outputs:
       run:
         - python
         - protobuf >=3.15.0,<5.0.0
-        - libprotobuf
       run_constrained:
         - grpcio >=1.0.0,<2.0.0
     test:


### PR DESCRIPTION
rebuild without libprotobuf as not needed, to see if does not need a dependency for new libprotobuf 4.23.4